### PR TITLE
release: v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
+## [1.0.1] - 2024-02-05
 - [PR 1](https://github.com/salesforce/django-request-queue-timeout/pull/1) Set up Dependabot, PR checks, and a CHANGELOG
 
 ## [1.0.0] - 2023-11-15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-request-queue-timeout"
-version = "1.0.0"
+version = "1.0.1"
 description = "Django middleware class to quickly dispatch any requests that wait too long in a queue before being processed"
 license = {file = "LICENSE.txt"}
 readme = "README.md"


### PR DESCRIPTION
- [PR 1](https://github.com/salesforce/django-request-queue-timeout/pull/1) Set up Dependabot, PR checks, and a CHANGELOG